### PR TITLE
Fixed cannot import name 'NaturalLanguageClassifierV1'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ matplotlib>=2.1.2
 aiohttp>=3.4
 configparser
 squarify>=0.3.0
-ibm-watson>=4.0.1
+ibm-watson>=4.0.1,<6.0.0
+ibm-cloud-sdk-core<=3.15.0
 seaborn>=0.9.0


### PR DESCRIPTION
Use prior version of the ibm-watson and ibm-cloud-sdk-core packages